### PR TITLE
Extra capability annotations for Easse and JSON RPC

### DIFF
--- a/osgi.enroute.base/src/osgi/enroute/capabilities/EasseWebResource.java
+++ b/osgi.enroute.base/src/osgi/enroute/capabilities/EasseWebResource.java
@@ -1,0 +1,20 @@
+package osgi.enroute.capabilities;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import osgi.enroute.namespace.WebResourceNamespace;
+import aQute.bnd.annotation.headers.RequireCapability;
+
+/**
+ * A Web Resource that provides Easse javascript files.
+ */
+@RequireCapability(ns = WebResourceNamespace.NS, filter = "(&(" + WebResourceNamespace.NS
+		+ "=/osgi/enroute/easse)${frange;1.3.0})")
+@Retention(RetentionPolicy.CLASS)
+public @interface EasseWebResource {
+
+	String[] resource() default {"easse.js","polyfill/eventsource.js"};
+
+	int priority() default 100;
+}

--- a/osgi.enroute.base/src/osgi/enroute/capabilities/JsonrpcExtender.java
+++ b/osgi.enroute.base/src/osgi/enroute/capabilities/JsonrpcExtender.java
@@ -1,0 +1,16 @@
+package osgi.enroute.capabilities;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.osgi.namespace.extender.ExtenderNamespace;
+
+import aQute.bnd.annotation.headers.RequireCapability;
+
+/**
+ * Require a JSON RPC to be available.
+ */
+@RequireCapability(ns = ExtenderNamespace.EXTENDER_NAMESPACE, filter = "(&(" + ExtenderNamespace.EXTENDER_NAMESPACE + "=osgi.enroute.jsonrpc)${frange;1.1.1})", effective = "active")
+@Retention(RetentionPolicy.CLASS)
+public @interface JsonrpcExtender {
+}

--- a/osgi.enroute.base/src/osgi/enroute/capabilities/JsonrpcWebResource.java
+++ b/osgi.enroute.base/src/osgi/enroute/capabilities/JsonrpcWebResource.java
@@ -1,0 +1,20 @@
+package osgi.enroute.capabilities;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import osgi.enroute.namespace.WebResourceNamespace;
+import aQute.bnd.annotation.headers.RequireCapability;
+
+/**
+ * A Web Resource that provides Jsonrpc javascript files.
+ */
+@RequireCapability(ns = WebResourceNamespace.NS, filter = "(&(" + WebResourceNamespace.NS
+		+ "=/osgi/enroute/jsonrpc)${frange;1.1.1})")
+@Retention(RetentionPolicy.CLASS)
+public @interface JsonrpcWebResource {
+
+	String[] resource() default {"jsonrpc.js"};
+
+	int priority() default 100;
+}


### PR DESCRIPTION
These commits provide extra provide-capability annotations for 
- Easse web resource : to be used when you want to include the Easse javascript angular module
- Json RPC web resource: to be used when you want to include the Json RPC javascript angular module
- Json RPC extender: to be used to indicate a dependency to Json RPC provider when you mark a service as Json RPC endpoint