### PR TITLE
Updated interfaces in the REST API should go here.

### DIFF
--- a/osgi.enroute.base.api/src/osgi/enroute/rest/api/Inf.java
+++ b/osgi.enroute.base.api/src/osgi/enroute/rest/api/Inf.java
@@ -6,10 +6,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to provide public information about a {@link REST} API.
- * 
- * Annotated functions will be parsed and the information displayed when calling 
- * /inf relative to the REST endpoint.
+ * Used to provide public information about a {@link REST} API. Annotated
+ * functions will be parsed and the information displayed when calling /inf
+ * relative to the base URI registered via a {@code UriMapper}.
  */
 @Target({ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)

--- a/osgi.enroute.base.api/src/osgi/enroute/rest/api/Inf.java
+++ b/osgi.enroute.base.api/src/osgi/enroute/rest/api/Inf.java
@@ -1,0 +1,22 @@
+package osgi.enroute.rest.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to provide public information about a {@link REST} API.
+ * 
+ * Annotated functions will be parsed and the information displayed when calling 
+ * /inf relative to the REST endpoint.
+ */
+@Target({ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Inf {
+
+	/**
+	 * Description of the method, parameter, or argument.
+	 */
+    String value();
+}

--- a/osgi.enroute.base.api/src/osgi/enroute/rest/api/REST.java
+++ b/osgi.enroute.base.api/src/osgi/enroute/rest/api/REST.java
@@ -19,7 +19,7 @@ import org.osgi.annotation.versioning.ConsumerType;
  * first upper case letter. The first part is the HTTP verb:
  * {@code get, put, delete, option, post}. The remaining parts are the URI
  * relative from the REST base URI. I.e. {@code getFoo} maps to
- * {@code http://host.com/rest/foo/bar}, assuming that the REST endpoint is
+ * {@code http://host.com/rest/foo/bar}, assuming that the base URI is
  * {@code http://host.com/rest}.
  * <p>
  * The first argument extends {@link RESTRequest} and thereby provides access to

--- a/osgi.enroute.base.api/src/osgi/enroute/rest/api/REST.java
+++ b/osgi.enroute.base.api/src/osgi/enroute/rest/api/REST.java
@@ -6,8 +6,7 @@ import org.osgi.annotation.versioning.ConsumerType;
  * A marker interface that allows a REST provider to call this class through
  * this interface. All the methods in the implementation class that have as
  * first argument an interface that extends {@link RESTRequest} become available
- * from the web. The actual URI depends on the {@code osgi.enroute.rest:rest}
- * configuration. By default this is {@code /rest}.
+ * from the web.
  * <p>
  * Incoming requests are used to construct a method name. The first part of the
  * method is the HTTP verb. That is, {@code GET, PUT, POST, DELETE, OPTION},
@@ -15,19 +14,23 @@ import org.osgi.annotation.versioning.ConsumerType;
  * compared case insensitive with any public methods that accept a
  * {@link RESTRequest} in their first argument.
  * <p>
- * The following segments, if any, are mapped to the arguments of the method. 
- * 
- *  
- *  
- *  The name of the method defines
- * the path. The method name is broken by on the first upper case letter. The
- * first part is the HTTP verb: {@code get, put, delete, option, post}. The
- * remaining parts are the URI relative from the REST base URI. I.e.
- * {@code getFoo} maps to {@code http://host.com/rest/foo/bar}, assuming that
- * the REST endpoint is {@code http://host.com/rest}.
+ * The following segments, if any, are mapped to the arguments of the method.
+ * The name of the method defines the path. The method name is broken by on the
+ * first upper case letter. The first part is the HTTP verb:
+ * {@code get, put, delete, option, post}. The remaining parts are the URI
+ * relative from the REST base URI. I.e. {@code getFoo} maps to
+ * {@code http://host.com/rest/foo/bar}, assuming that the REST endpoint is
+ * {@code http://host.com/rest}.
  * <p>
  * The first argument extends {@link RESTRequest} and thereby provides access to
  * the request information.
+ * <p>
+ * For larger systems, it is possible to subdivide REST methods by providing a
+ * namespace. Accomplishing this is a two-step process. First, you must register
+ * a class implementing this {@code REST} interface with the property:
+ * {@code org.enroute.rest.namespace} set to the desired namespace. Second, you
+ * must register a {@code UriMapper} that will map the HTTP request URI to the
+ * namespace. Note that the default namespace is the empty string "".
  * <p>
  * It must be realized that any of the web request methods is called from
  * outside the system and requires proper security checks.

--- a/osgi.enroute.base.api/src/osgi/enroute/rest/api/RESTRequest.java
+++ b/osgi.enroute.base.api/src/osgi/enroute/rest/api/RESTRequest.java
@@ -22,7 +22,6 @@ import org.osgi.annotation.versioning.ProviderType;
  * in the previous example one can add a {@code int[] abc()} method to the
  * extended interface. If the parameter is not present, null is returned or 0 if
  * it is a Number.
- * 
  */
 
 @ProviderType

--- a/osgi.enroute.base.api/src/osgi/enroute/rest/api/RestConstants.java
+++ b/osgi.enroute.base.api/src/osgi/enroute/rest/api/RestConstants.java
@@ -1,7 +1,7 @@
 package osgi.enroute.rest.api;
 
 /**
- * Specification of the JSONRPC API
+ * Constants for describing the osgi.enroute.rest.api interface.
  */
 public interface RestConstants {
 	/**

--- a/osgi.enroute.base.api/src/osgi/enroute/rest/api/UriMapper.java
+++ b/osgi.enroute.base.api/src/osgi/enroute/rest/api/UriMapper.java
@@ -1,0 +1,27 @@
+package osgi.enroute.rest.api;
+
+/**
+ * Used to map a request URI to a REST namespace.
+ * 
+ * Register a service that implements this interface in order to configure
+ * a REST endpoint. The path of the servlet that is instantiated behind the scenes
+ * will have the servlet path provided by this service configuration (using the
+ * {@code HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN} configuration property.
+ * Multiple {@code UriMapper}s can be registred against the same servlet pattern. Priority
+ * is determined by setting the {@code Constants.SERVICE_RANKING} property.
+ */
+@FunctionalInterface
+public interface UriMapper {
+    /**
+     * Returns the REST namespace associated to the provided URI.
+     * 
+     * If the mapping is out-of-scope, then {@code null} is returned, and the
+     * next highest {@code UriMapper} will be tried. If no mappers are in scope,
+     * finally the default namespace (empty string) will be used. 
+     * 
+     * @param uri the URI against which the REST namespace is mapped
+     * @return the namespce mapped to the URI. An empty string is the default
+     *         namespace.
+     */
+    String namespaceFor(String uri);
+}

--- a/osgi.enroute.base.api/src/osgi/enroute/rest/api/UriMapper.java
+++ b/osgi.enroute.base.api/src/osgi/enroute/rest/api/UriMapper.java
@@ -4,7 +4,10 @@ package osgi.enroute.rest.api;
  * Used to map a request URI to a REST namespace.
  * 
  * Register a service that implements this interface in order to configure
- * a REST endpoint. The path of the servlet that is instantiated behind the scenes
+ * a REST URI service hook. That is, expose a URI that will either be a base URI
+ * for several endpoints, or an endpoint in itself.
+ * 
+ * The path of the servlet that is instantiated behind the scenes
  * will have the servlet path provided by this service configuration (using the
  * {@code HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN} configuration property.
  * Multiple {@code UriMapper}s can be registred against the same servlet pattern. Priority


### PR DESCRIPTION
When making my PRs in the REST provider bundle, it was easier to put the new interfaces there.

Now that the work appears to be stabilized, those classes need to be moved here.
