### PR TITLE
[configurer] Added support for configurator policy

### DIFF
--- a/osgi.enroute.configurer.simple.provider/src/osgi/enroute/configurer/simple/provider/Configurer.java
+++ b/osgi.enroute.configurer.simple.provider/src/osgi/enroute/configurer/simple/provider/Configurer.java
@@ -294,12 +294,19 @@ public class Configurer implements ConfigurationDone {
 					configuration = cm.getConfiguration(pid, "?");
 				}
 
+				Dictionary<?, ?> current = configuration.getProperties();
+				if (current != null) {
+
+					Object policy = dictionary.remove(":configurator:policy");
+					if (!"force".equals(policy))
+						continue;
+
+					if (isEqual(dictionary, current))
+						continue;
+
+				}
+
 				configuration.setBundleLocation("?");
-
-				Dictionary< ? , ? > current = configuration.getProperties();
-				if (current != null && isEqual(dictionary, current))
-					continue;
-
 				configuration.update(dictionary);
 			}
 		}

--- a/osgi.enroute.scheduler.simple.provider/test/osgi/enroute/scheduler/simple/provider/SchedulerTest.java
+++ b/osgi.enroute.scheduler.simple.provider/test/osgi/enroute/scheduler/simple/provider/SchedulerTest.java
@@ -29,18 +29,14 @@ public class SchedulerTest extends TestCase {
 			@Override
 			public void run(TestData data) throws Exception {
 				// TODO Auto-generated method stub
-				
+
 			}
 		};
 		assertEquals(TestData.class, si.getType(cj));
 	}
-	
-	
-	
-	@Override
-	public void setUp() {
-		si.activate();
-	}
+
+
+
 
 	@Override
 	public void tearDown() {


### PR DESCRIPTION
The new Configurator spec that was derived from the
OSGi enRoute Configurer specifies an override 
policy with ‘force’. This policy was added to this
bundle.

This should be backward compatible.