### PR TITLE
Include OSGi annotations in the osgi-api pom

### DIFF
--- a/indexes/osgi-api/pom.xml
+++ b/indexes/osgi-api/pom.xml
@@ -23,5 +23,10 @@
             <artifactId>osgi.cmpn</artifactId>
             <version>7.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
These should be available for declaring API versions

Signed-off-by: Tim Ward <tim.ward@paremus.com>