### PR TITLE
Try using built in mvn as recommended by AppVeyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,7 @@ install:
   - mvnw.cmd --version
 
 build_script:
-  - mvnw.cmd verify
+  - mvn verify
 
 on_success:
   - git status
-
-cache:
-  - C:\Users\appveyor\.m2\wrapper -> .mvn\wrapper\maven-wrapper.properties


### PR DESCRIPTION
According to the AppVeyor support team the source of our slow builds is the maven wrapper that we use. This leads me to believe that AppVeyor have some special settings in their Maven installation which we lose by using the wrapper. This commit switches to using the AppVeyor installed mvn command

Signed-off-by: Tim Ward <tim.ward@paremus.com>