### PR TITLE
Add dependencies for indexes to archetypes so that we always test the…

### DIFF
--- a/archetypes/api/pom.xml
+++ b/archetypes/api/pom.xml
@@ -10,5 +10,12 @@
     <packaging>maven-archetype</packaging>
 
     <description>An archetype for generating an OSGi enRoute R7 API module</description>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-invoker-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/archetypes/application/pom.xml
+++ b/archetypes/application/pom.xml
@@ -37,18 +37,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.0.1</version>
                 <configuration>
                     <failIfNoProjects>true</failIfNoProjects>
                     <cloneClean>false</cloneClean>
                     <pom>${project.build.directory}/test-classes/projects/build/application-test/project/basic/pom.xml</pom>
-                    <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
                 </configuration>
                 <executions>
                     <execution>
                         <id>test-archetype</id>
                         <goals>
-                            <goal>install</goal>
                             <goal>run</goal>
                         </goals>
                     </execution>

--- a/archetypes/ds-component/pom.xml
+++ b/archetypes/ds-component/pom.xml
@@ -10,5 +10,12 @@
     <packaging>maven-archetype</packaging>
 
     <description>An archetype for generating an OSGi enRoute R7 Declarative Services Component module</description>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-invoker-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -74,6 +74,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <test.repo>${project.build.directory}/it-repo</test.repo>
+        <test.settings>../settings.xml</test.settings>
     </properties>
 
     <modules>
@@ -84,6 +86,35 @@
         <module>application</module>
         <module>api</module>
     </modules>
+
+    <!-- All archetypes depend on these to ensure the latest versions are 
+        used in testing -->
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi.enroute.r7</groupId>
+            <artifactId>osgi-api</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi.enroute.r7</groupId>
+            <artifactId>enterprise-api</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi.enroute.r7</groupId>
+            <artifactId>impl-index</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi.enroute.r7</groupId>
+            <artifactId>debug-bundles</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
 
     <build>
         <extensions>
@@ -101,7 +132,29 @@
                     <version>3.0.1</version>
                     <configuration>
                         <ignoreEOLStyle>true</ignoreEOLStyle>
+                        <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+                        <settingsFile>${test.settings}</settingsFile>
                     </configuration>
+                </plugin>
+                <!-- Install the dependencies into the test repo so the latest 
+                    versions are used in testing -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <configuration>
+                        <localRepositoryPath>${test.repo}</localRepositoryPath>
+                        <settingsFile>${test.settings}</settingsFile>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>install-test-deps</id>
+                            <goals>
+                                <goal>install</goal>
+                            </goals>
+                            <phase>pre-integration-test</phase>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/archetypes/project/pom.xml
+++ b/archetypes/project/pom.xml
@@ -38,18 +38,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.0.1</version>
                 <configuration>
                     <failIfNoProjects>true</failIfNoProjects>
                     <cloneClean>false</cloneClean>
                     <pom>${project.build.directory}/test-classes/projects/basic/project/basic/pom.xml</pom>
-                    <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
                 </configuration>
                 <executions>
                     <execution>
                         <id>test-archetype</id>
                         <goals>
-                            <goal>install</goal>
                             <goal>run</goal>
                         </goals>
                     </execution>

--- a/archetypes/rest-component/pom.xml
+++ b/archetypes/rest-component/pom.xml
@@ -10,5 +10,12 @@
     <packaging>maven-archetype</packaging>
 
     <description>An archetype for generating an OSGi enRoute R7 JAX-RS Whiteboard Component module</description>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-invoker-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/archetypes/settings.xml
+++ b/archetypes/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     
     <modules>
         <module>indexes</module>
-        <module>examples</module>
         <module>archetypes</module>
+        <module>examples</module>
     </modules>
 </project>


### PR DESCRIPTION
… current build

This combined with the invoker:install goal puts the just-built indexes into the repositories used to test the archetypes.

This commit also enables "fast builds" as described by the maven-invoker-plugin to avoid making the overall build too slow

Signed-off-by: Tim Ward <tim.ward@paremus.com>