### PR TITLE
Tidy up examples, and remove r7 from the groupId

### DIFF
--- a/archetypes/api/pom.xml
+++ b/archetypes/api/pom.xml
@@ -2,9 +2,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.osgi.enroute.r7.archetype</groupId>
+        <groupId>org.osgi.enroute.archetype</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>api</artifactId>
     <packaging>maven-archetype</packaging>

--- a/archetypes/api/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/api/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/api/src/test/resources/projects/build/archetype.pom.properties
+++ b/archetypes/api/src/test/resources/projects/build/archetype.pom.properties
@@ -1,3 +1,3 @@
-groupId = org.osgi.enroute.r7.archetype
+groupId = org.osgi.enroute.archetype
 artifactId = project
-version = 0.0.1-SNAPSHOT
+version = 7.0.0-SNAPSHOT

--- a/archetypes/api/src/test/resources/projects/check/reference/pom.xml
+++ b/archetypes/api/src/test/resources/projects/check/reference/pom.xml
@@ -11,7 +11,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/application/pom.xml
+++ b/archetypes/application/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.osgi.enroute.r7.archetype</groupId>
+        <groupId>org.osgi.enroute.archetype</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>application</artifactId>

--- a/archetypes/application/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/application/src/main/resources/archetype-resources/pom.xml
@@ -15,12 +15,12 @@
             <version>${impl-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>impl-index</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>debug-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/application/src/test/resources/projects/build/archetype.pom.properties
+++ b/archetypes/application/src/test/resources/projects/build/archetype.pom.properties
@@ -1,3 +1,3 @@
-groupId = org.osgi.enroute.r7.archetype
+groupId = org.osgi.enroute.archetype
 artifactId = project
-version = 0.0.1-SNAPSHOT
+version = 7.0.0-SNAPSHOT

--- a/archetypes/application/src/test/resources/projects/check/reference/pom.xml
+++ b/archetypes/application/src/test/resources/projects/check/reference/pom.xml
@@ -15,12 +15,12 @@
             <version>0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>impl-index</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>debug-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/ds-component/pom.xml
+++ b/archetypes/ds-component/pom.xml
@@ -2,9 +2,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.osgi.enroute.r7.archetype</groupId>
+        <groupId>org.osgi.enroute.archetype</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>ds-component</artifactId>
     <packaging>maven-archetype</packaging>

--- a/archetypes/ds-component/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/ds-component/src/main/resources/archetype-resources/pom.xml
@@ -11,12 +11,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>test-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/ds-component/src/test/resources/projects/build/archetype.pom.properties
+++ b/archetypes/ds-component/src/test/resources/projects/build/archetype.pom.properties
@@ -1,3 +1,3 @@
-groupId = org.osgi.enroute.r7.archetype
+groupId = org.osgi.enroute.archetype
 artifactId = project
-version = 0.0.1-SNAPSHOT
+version = 7.0.0-SNAPSHOT

--- a/archetypes/ds-component/src/test/resources/projects/check/reference/pom.xml
+++ b/archetypes/ds-component/src/test/resources/projects/check/reference/pom.xml
@@ -11,12 +11,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>test-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -4,11 +4,11 @@
     xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.osgi.enroute.r7.archetype</groupId>
+    <groupId>org.osgi.enroute.archetype</groupId>
     <artifactId>archetypes</artifactId>
     <name>OSGi enRoute Archetypes parent</name>
     <packaging>pom</packaging>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>7.0.0-SNAPSHOT</version>
 
     <description>The parent for generating the Maven archetypes for OSGi enRoute R7</description>
 
@@ -91,27 +91,27 @@
         used in testing -->
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>7.0.0-SNAPSHOT</version>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>enterprise-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>7.0.0-SNAPSHOT</version>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>impl-index</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>7.0.0-SNAPSHOT</version>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>debug-bundles</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>7.0.0-SNAPSHOT</version>
             <type>pom</type>
         </dependency>
     </dependencies>

--- a/archetypes/project-bare/pom.xml
+++ b/archetypes/project-bare/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.osgi.enroute.r7.archetype</groupId>
+        <groupId>org.osgi.enroute.archetype</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>project-bare</artifactId>

--- a/archetypes/project-bare/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/project-bare/src/main/resources/archetype-resources/pom.xml
@@ -57,37 +57,37 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>osgi-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>enterprise-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>impl-index</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>debug-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>test-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>

--- a/archetypes/project-bare/src/test/resources/projects/basic/reference/pom.xml
+++ b/archetypes/project-bare/src/test/resources/projects/basic/reference/pom.xml
@@ -57,37 +57,37 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>osgi-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>enterprise-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>impl-index</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>debug-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>test-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>

--- a/archetypes/project/pom.xml
+++ b/archetypes/project/pom.xml
@@ -4,9 +4,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.osgi.enroute.r7.archetype</groupId>
+        <groupId>org.osgi.enroute.archetype</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>project</artifactId>

--- a/archetypes/project/src/main/resources/archetype-resources/__app-artifactId__/pom.xml
+++ b/archetypes/project/src/main/resources/archetype-resources/__app-artifactId__/pom.xml
@@ -19,12 +19,12 @@
             <version>${version}</version>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>impl-index</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>debug-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/project/src/main/resources/archetype-resources/__impl-artifactId__/pom.xml
+++ b/archetypes/project/src/main/resources/archetype-resources/__impl-artifactId__/pom.xml
@@ -13,17 +13,17 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>enterprise-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>test-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/project/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/project/src/main/resources/archetype-resources/pom.xml
@@ -62,37 +62,37 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>osgi-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>enterprise-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>impl-index</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>debug-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>test-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>

--- a/archetypes/project/src/test/resources/projects/basic/reference/app-module/pom.xml
+++ b/archetypes/project/src/test/resources/projects/basic/reference/app-module/pom.xml
@@ -19,12 +19,12 @@
             <version>0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>impl-index</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>debug-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/project/src/test/resources/projects/basic/reference/impl-bundle/pom.xml
+++ b/archetypes/project/src/test/resources/projects/basic/reference/impl-bundle/pom.xml
@@ -13,17 +13,17 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>enterprise-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>test-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/project/src/test/resources/projects/basic/reference/pom.xml
+++ b/archetypes/project/src/test/resources/projects/basic/reference/pom.xml
@@ -62,37 +62,37 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>osgi-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>enterprise-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>impl-index</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>debug-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>test-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>

--- a/archetypes/rest-component/pom.xml
+++ b/archetypes/rest-component/pom.xml
@@ -2,9 +2,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.osgi.enroute.r7.archetype</groupId>
+        <groupId>org.osgi.enroute.archetype</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>rest-component</artifactId>
     <packaging>maven-archetype</packaging>

--- a/archetypes/rest-component/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/rest-component/src/main/resources/archetype-resources/pom.xml
@@ -11,17 +11,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>enterprise-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>test-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/archetypes/rest-component/src/test/resources/projects/basic/archetype.pom.properties
+++ b/archetypes/rest-component/src/test/resources/projects/basic/archetype.pom.properties
@@ -1,3 +1,3 @@
-groupId = org.osgi.enroute.r7.archetype
+groupId = org.osgi.enroute.archetype
 artifactId = project
-version = 0.0.1-SNAPSHOT
+version = 7.0.0-SNAPSHOT

--- a/archetypes/rest-component/src/test/resources/projects/check/reference/pom.xml
+++ b/archetypes/rest-component/src/test/resources/projects/check/reference/pom.xml
@@ -11,17 +11,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>enterprise-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>test-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -106,6 +106,46 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.osgi.enroute.r7</groupId>
+                <artifactId>osgi-api</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi.enroute.r7</groupId>
+                <artifactId>enterprise-api</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi.enroute.r7</groupId>
+                <artifactId>impl-index</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi.enroute.r7</groupId>
+                <artifactId>debug-bundles</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi.enroute.r7</groupId>
+                <artifactId>test-bundles</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -183,6 +223,43 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                                     <scope>test</scope>
                                 </scopes>
                             </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                                <!-- Define the version of the resolver plugin we use -->
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-resolver-maven-plugin</artifactId>
+                    <version>4.0.0-SNAPSHOT</version>
+                    <configuration>
+                        <failOnChanges>false</failOnChanges>
+                        <bndruns>
+                        </bndruns>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>resolve</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- Define the version of the baseline plugin we use and 
+                    avoid failing when no baseline jar exists. (for example before the first 
+                    release) -->
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-baseline-maven-plugin</artifactId>
+                    <version>4.0.0-SNAPSHOT</version>
+                    <configuration>
+                        <failOnMissing>false</failOnMissing>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>baseline</goal>
+                            </goals>
                         </execution>
                     </executions>
                 </plugin>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -109,37 +109,37 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>osgi-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>enterprise-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>impl-index</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>debug-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
+                <groupId>org.osgi.enroute</groupId>
                 <artifactId>test-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>7.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>test</scope>
             </dependency>

--- a/examples/quickstart/app/pom.xml
+++ b/examples/quickstart/app/pom.xml
@@ -46,6 +46,16 @@
                     </bndruns>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-resolver-maven-plugin</artifactId>
+                <configuration>
+                    <bndruns>
+                        <bndrun>app.bndrun</bndrun>
+                        <bndrun>debug.bndrun</bndrun>
+                    </bndruns>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/examples/quickstart/app/pom.xml
+++ b/examples/quickstart/app/pom.xml
@@ -19,13 +19,13 @@
         </dependency>
         
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>impl-index</artifactId>
             <type>pom</type>
         </dependency>
 
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>debug-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -13,46 +13,6 @@
 
     <description>The quickstart OSGi enRoute example - a one page app using a REST microservice</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
-                <artifactId>osgi-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
-                <artifactId>enterprise-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
-                <artifactId>impl-index</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
-                <artifactId>debug-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi.enroute.r7</groupId>
-                <artifactId>test-bundles</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <modules>
         <module>rest</module>
         <module>app</module>

--- a/examples/quickstart/rest/pom.xml
+++ b/examples/quickstart/rest/pom.xml
@@ -12,17 +12,17 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>osgi-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>enterprise-api</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.osgi.enroute.r7</groupId>
+            <groupId>org.osgi.enroute</groupId>
             <artifactId>test-bundles</artifactId>
             <type>pom</type>
         </dependency>

--- a/indexes/debug-bundles/pom.xml
+++ b/indexes/debug-bundles/pom.xml
@@ -2,9 +2,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.osgi.enroute.r7</groupId>
+        <groupId>org.osgi.enroute</groupId>
         <artifactId>indexes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>debug-bundles</artifactId>
     <packaging>pom</packaging>

--- a/indexes/enterprise-api/pom.xml
+++ b/indexes/enterprise-api/pom.xml
@@ -2,9 +2,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.osgi.enroute.r7</groupId>
+        <groupId>org.osgi.enroute</groupId>
         <artifactId>indexes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>enterprise-api</artifactId>
     <packaging>pom</packaging>

--- a/indexes/impl-index/pom.xml
+++ b/indexes/impl-index/pom.xml
@@ -2,9 +2,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.osgi.enroute.r7</groupId>
+        <groupId>org.osgi.enroute</groupId>
         <artifactId>indexes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>impl-index</artifactId>

--- a/indexes/osgi-api/pom.xml
+++ b/indexes/osgi-api/pom.xml
@@ -2,9 +2,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.osgi.enroute.r7</groupId>
+        <groupId>org.osgi.enroute</groupId>
         <artifactId>indexes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>osgi-api</artifactId>

--- a/indexes/pom.xml
+++ b/indexes/pom.xml
@@ -4,11 +4,11 @@
     xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.osgi.enroute.r7</groupId>
+    <groupId>org.osgi.enroute</groupId>
     <artifactId>indexes</artifactId>
     <name>OSGi enRoute indexes parent</name>
     <packaging>pom</packaging>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>7.0.0-SNAPSHOT</version>
 
     <description>The parent for generating the R7 OSGi indexes used by enRoute</description>
 

--- a/indexes/test-bundles/pom.xml
+++ b/indexes/test-bundles/pom.xml
@@ -2,9 +2,9 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.osgi.enroute.r7</groupId>
+        <groupId>org.osgi.enroute</groupId>
         <artifactId>indexes</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-bundles</artifactId>


### PR DESCRIPTION
The maven modules should use the OSGi release version in their version information. 