### PR TITLE
RestServlet is not closed on deregistration.

### DIFF
--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestControllerService.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestControllerService.java
@@ -100,6 +100,7 @@ public class RestControllerService {
 						log.trace("removing REST %s on %s", resourceManager, namespace);
 						RestServlet rs = servlets.get(namespace);
 						rs.remove(resourceManager);
+						rs.close();
 
 						// we never clean them up. Seems to much work
 						// since it is likely that the namespace is reused.


### PR DESCRIPTION
The servlet does not get closed upon deregistration. This causes the servlet path to be shadowed and breaks subsequent calls to that path.

This small patch simply closes the servlet and fixed the problem.