### PR TITLE
Add the application project artifactId as the name of the index

### DIFF
--- a/archetypes/application/src/main/resources/archetype-resources/__artifactId__.bndrun
+++ b/archetypes/application/src/main/resources/archetype-resources/__artifactId__.bndrun
@@ -1,4 +1,4 @@
-index: target/index.xml
+index: target/index.xml;name="${artifactId}"
 
 -standalone: ${index}
 

--- a/archetypes/application/src/main/resources/archetype-resources/debug.bndrun
+++ b/archetypes/application/src/main/resources/archetype-resources/debug.bndrun
@@ -1,6 +1,6 @@
 -include: ~${artifactId}.bndrun
 
-test-index: target/test-index.xml
+test-index: target/test-index.xml;name="${artifactId} Test"
 
 -standalone: ${index},${test-index}
 

--- a/archetypes/application/src/test/resources/projects/check/reference/debug.bndrun
+++ b/archetypes/application/src/test/resources/projects/check/reference/debug.bndrun
@@ -1,6 +1,6 @@
 -include: ~standalone-app-module.bndrun
 
-test-index: target/test-index.xml
+test-index: target/test-index.xml;name="standalone-app-module Test"
 
 -standalone: ${index},${test-index}
 

--- a/archetypes/application/src/test/resources/projects/check/reference/standalone-app-module.bndrun
+++ b/archetypes/application/src/test/resources/projects/check/reference/standalone-app-module.bndrun
@@ -1,4 +1,4 @@
-index: target/index.xml
+index: target/index.xml;name="standalone-app-module"
 
 -standalone: ${index}
 

--- a/archetypes/project-bare/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/project-bare/src/main/resources/archetype-resources/pom.xml
@@ -146,6 +146,9 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                             <goals>
                                 <goal>index</goal>
                             </goals>
+                            <configuration>
+                                <indexName>${project.artifactId}</indexName>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>test-index</id>
@@ -153,6 +156,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                                 <goal>index</goal>
                             </goals>
                             <configuration>
+                                <indexName>${project.artifactId}</indexName>
                                 <outputFile>${project.build.directory}/test-index.xml</outputFile>
                                 <scopes>
                                     <scope>test</scope>

--- a/archetypes/project-bare/src/test/resources/projects/basic/reference/pom.xml
+++ b/archetypes/project-bare/src/test/resources/projects/basic/reference/pom.xml
@@ -146,6 +146,9 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                             <goals>
                                 <goal>index</goal>
                             </goals>
+                            <configuration>
+                                <indexName>${project.artifactId}</indexName>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>test-index</id>
@@ -153,6 +156,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                                 <goal>index</goal>
                             </goals>
                             <configuration>
+                                <indexName>${project.artifactId}</indexName>
                                 <outputFile>${project.build.directory}/test-index.xml</outputFile>
                                 <scopes>
                                     <scope>test</scope>

--- a/archetypes/project/src/main/resources/archetype-resources/__app-artifactId__/__app-artifactId__.bndrun
+++ b/archetypes/project/src/main/resources/archetype-resources/__app-artifactId__/__app-artifactId__.bndrun
@@ -1,4 +1,4 @@
-index: target/index.xml
+index: target/index.xml;name="${app-artifactId}"
 
 -standalone: ${index}
 

--- a/archetypes/project/src/main/resources/archetype-resources/__app-artifactId__/debug.bndrun
+++ b/archetypes/project/src/main/resources/archetype-resources/__app-artifactId__/debug.bndrun
@@ -1,6 +1,6 @@
 -include: ~${app-artifactId}.bndrun
 
-test-index: target/test-index.xml
+test-index: target/test-index.xml;name="${app-artifactId} Test"
 
 -standalone: ${index},${test-index}
 

--- a/archetypes/project/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/project/src/main/resources/archetype-resources/pom.xml
@@ -151,6 +151,9 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                             <goals>
                                 <goal>index</goal>
                             </goals>
+                            <configuration>
+                                <indexName>${project.artifactId}</indexName>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>test-index</id>
@@ -158,6 +161,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                                 <goal>index</goal>
                             </goals>
                             <configuration>
+                                <indexName>${project.artifactId} Test</indexName>
                                 <outputFile>${project.build.directory}/test-index.xml</outputFile>
                                 <scopes>
                                     <scope>test</scope>

--- a/archetypes/project/src/test/resources/projects/basic/reference/app-module/app-module.bndrun
+++ b/archetypes/project/src/test/resources/projects/basic/reference/app-module/app-module.bndrun
@@ -1,4 +1,4 @@
-index: target/index.xml
+index: target/index.xml;name="app-module"
 
 -standalone: ${index}
 

--- a/archetypes/project/src/test/resources/projects/basic/reference/app-module/debug.bndrun
+++ b/archetypes/project/src/test/resources/projects/basic/reference/app-module/debug.bndrun
@@ -1,6 +1,6 @@
 -include: ~app-module.bndrun
 
-test-index: target/test-index.xml
+test-index: target/test-index.xml;name="app-module Test"
 
 -standalone: ${index},${test-index}
 

--- a/archetypes/project/src/test/resources/projects/basic/reference/pom.xml
+++ b/archetypes/project/src/test/resources/projects/basic/reference/pom.xml
@@ -151,6 +151,9 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                             <goals>
                                 <goal>index</goal>
                             </goals>
+                            <configuration>
+                                <indexName>${project.artifactId}</indexName>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>test-index</id>
@@ -158,6 +161,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                                 <goal>index</goal>
                             </goals>
                             <configuration>
+                                <indexName>${project.artifactId} Test</indexName>
                                 <outputFile>${project.build.directory}/test-index.xml</outputFile>
                                 <scopes>
                                     <scope>test</scope>

--- a/examples/microservice/rest-app-jpa/debug.bndrun
+++ b/examples/microservice/rest-app-jpa/debug.bndrun
@@ -1,6 +1,6 @@
 -include: ~rest-app-jpa.bndrun
 
-test-index: target/test-index.xml
+test-index: target/test-index.xml;name="rest-app-jpa Test"
 
 -standalone: ${index},${test-index}
 

--- a/examples/microservice/rest-app-jpa/rest-app-jpa.bndrun
+++ b/examples/microservice/rest-app-jpa/rest-app-jpa.bndrun
@@ -1,4 +1,4 @@
-index: target/index.xml
+index: target/index.xml;name="rest-app-jpa"
 
 -standalone: ${index}
 

--- a/examples/microservice/rest-app/debug.bndrun
+++ b/examples/microservice/rest-app/debug.bndrun
@@ -1,6 +1,6 @@
 -include: ~rest-app.bndrun
 
-test-index: target/test-index.xml
+test-index: target/test-index.xml;name="rest-app Test"
 
 -standalone: ${index},${test-index}
 

--- a/examples/microservice/rest-app/rest-app.bndrun
+++ b/examples/microservice/rest-app/rest-app.bndrun
@@ -1,4 +1,4 @@
-index: target/index.xml
+index: target/index.xml;name="rest-app"
 
 -standalone: ${index}
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -212,6 +212,9 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                             <goals>
                                 <goal>index</goal>
                             </goals>
+                            <configuration>
+                                <indexName>${project.artifactId}</indexName>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>test-index</id>
@@ -219,6 +222,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                                 <goal>index</goal>
                             </goals>
                             <configuration>
+                                <indexName>${project.artifactId}</indexName>
                                 <outputFile>${project.build.directory}/test-index.xml</outputFile>
                                 <scopes>
                                     <scope>test</scope>

--- a/examples/quickstart/app/app.bndrun
+++ b/examples/quickstart/app/app.bndrun
@@ -1,4 +1,4 @@
-index: target/index.xml
+index: target/index.xml;name="app"
 
 -standalone: ${index}
 

--- a/examples/quickstart/app/debug.bndrun
+++ b/examples/quickstart/app/debug.bndrun
@@ -1,6 +1,6 @@
 -include: ~app.bndrun
 
-test-index: target/test-index.xml
+test-index: target/test-index.xml;name="app Test"
 
 -standalone: ${index},${test-index}
 


### PR DESCRIPTION
This applies both to the name in the index.xml and also to the repository in the bndrun. Test indexes include " Test" as a suffix

Fixes #56 