### PR TITLE
Update to released R7 RIs

### DIFF
--- a/archetypes/application/src/main/resources/archetype-resources/__artifactId__.bndrun
+++ b/archetypes/application/src/main/resources/archetype-resources/__artifactId__.bndrun
@@ -3,5 +3,5 @@ index: target/index.xml;name="${artifactId}"
 -standalone: ${index}
 
 -runrequires: osgi.identity;filter:='(osgi.identity=${impl-groupId}.${impl-artifactId})'
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8

--- a/archetypes/application/src/test/resources/projects/check/reference/standalone-app-module.bndrun
+++ b/archetypes/application/src/test/resources/projects/check/reference/standalone-app-module.bndrun
@@ -3,5 +3,5 @@ index: target/index.xml;name="standalone-app-module"
 -standalone: ${index}
 
 -runrequires: osgi.identity;filter:='(osgi.identity=archetype.it.impl-bundle)'
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8

--- a/archetypes/bundle-test/src/main/resources/archetype-resources/integration-test.bndrun
+++ b/archetypes/bundle-test/src/main/resources/archetype-resources/integration-test.bndrun
@@ -12,7 +12,7 @@ Import-Package: org.osgi.framework.*;version="[1.8,2)",*
 # Used by Objenesis/Mockito and not actually optional
 -runsystempackages: sun.reflect
 
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8
 
 -runrequires: \

--- a/archetypes/bundle-test/src/test/resources/projects/check/reference/integration-test.bndrun
+++ b/archetypes/bundle-test/src/test/resources/projects/check/reference/integration-test.bndrun
@@ -12,7 +12,7 @@ Import-Package: org.osgi.framework.*;version="[1.8,2)",*
 # Used by Objenesis/Mockito and not actually optional
 -runsystempackages: sun.reflect
 
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8
 
 -runrequires: \

--- a/archetypes/project/src/main/resources/archetype-resources/__app-artifactId__/__app-artifactId__.bndrun
+++ b/archetypes/project/src/main/resources/archetype-resources/__app-artifactId__/__app-artifactId__.bndrun
@@ -3,5 +3,5 @@ index: target/index.xml;name="${app-artifactId}"
 -standalone: ${index}
 
 -runrequires: osgi.identity;filter:='(osgi.identity=${groupId}.${impl-artifactId})'
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8

--- a/archetypes/project/src/test/resources/projects/basic/reference/app-module/app-module.bndrun
+++ b/archetypes/project/src/test/resources/projects/basic/reference/app-module/app-module.bndrun
@@ -3,5 +3,5 @@ index: target/index.xml;name="app-module"
 -standalone: ${index}
 
 -runrequires: osgi.identity;filter:='(osgi.identity=archetype.it.impl-bundle)'
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8

--- a/examples/microservice/rest-app-jpa/rest-app-jpa.bndrun
+++ b/examples/microservice/rest-app-jpa/rest-app-jpa.bndrun
@@ -23,15 +23,14 @@ index: target/index.xml;name="rest-app-jpa"
 	osgi.identity;filter:='(osgi.identity=org.apache.johnzon.core)',\
 	osgi.identity;filter:='(osgi.identity=org.h2)',\
 	bnd.identity;version='0.0.1.201801031655';id='org.osgi.enroute.examples.microservice.rest-app-jpa'
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	org.apache.aries.javax.annotation-api;version='[0.0.1,0.0.2)',\
-	org.apache.aries.javax.jax.rs-api;version='[0.0.1,0.0.2)',\
-	org.apache.aries.jax.rs.whiteboard;version='[0.0.1,0.0.2)',\
-	org.apache.felix.configadmin;version='[1.9.0,1.9.1)',\
+	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.0,1.0.1)',\
+	org.apache.felix.configadmin;version='[1.9.2,1.9.3)',\
 	org.apache.felix.http.jetty;version='[4.0.0,4.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.0,2.1.1)',\
@@ -62,4 +61,4 @@ index: target/index.xml;name="rest-app-jpa"
 	org.osgi.enroute.examples.microservice.dao-impl-jpa;version='[0.0.1,0.0.2)',\
 	org.osgi.enroute.examples.microservice.rest-app-jpa;version='[0.0.1,0.0.2)',\
 	tx-control-provider-jpa-xa;version='[1.0.0,1.0.1)',\
-	osgi.cmpn;version='[4.3.1,4.3.2)'
+	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)'

--- a/examples/microservice/rest-app/rest-app.bndrun
+++ b/examples/microservice/rest-app/rest-app.bndrun
@@ -9,15 +9,14 @@ index: target/index.xml;name="rest-app"
 	osgi.identity;filter:='(osgi.identity=org.apache.johnzon.core)',\
 	osgi.identity;filter:='(osgi.identity=org.h2)',\
 	bnd.identity;version='0.0.1.201801031655';id='org.osgi.enroute.examples.microservice.rest-app'
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	org.apache.aries.javax.annotation-api;version='[0.0.1,0.0.2)',\
-	org.apache.aries.javax.jax.rs-api;version='[0.0.1,0.0.2)',\
-	org.apache.aries.jax.rs.whiteboard;version='[0.0.1,0.0.2)',\
-	org.apache.felix.configadmin;version='[1.9.0,1.9.1)',\
+	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.0,1.0.1)',\
+	org.apache.felix.configadmin;version='[1.9.2,1.9.3)',\
 	org.apache.felix.http.jetty;version='[4.0.0,4.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.0,2.1.1)',\
@@ -35,4 +34,5 @@ index: target/index.xml;name="rest-app"
 	org.apache.felix.configurator;version='[1.0.0,1.0.1)',\
 	org.osgi.enroute.examples.microservice.rest-app;version='[0.0.1,0.0.2)',\
 	org.apache.servicemix.specs.json-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.johnzon.core;version='[1.1.0,1.1.1)'
+	org.apache.johnzon.core;version='[1.1.0,1.1.1)',\
+	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)'

--- a/examples/microservice/rest-service-test/integration-test.bndrun
+++ b/examples/microservice/rest-service-test/integration-test.bndrun
@@ -12,7 +12,7 @@ Import-Package: org.osgi.framework.*;version="[1.8,2)",*
 # Used by Objenesis/Mockito and not actually optional
 -runsystempackages: sun.reflect
 
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8
 
 -runrequires: \
@@ -24,10 +24,9 @@ Import-Package: org.osgi.framework.*;version="[1.8,2)",*
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
-	org.apache.aries.javax.annotation-api;version='[0.0.1,0.0.2)',\
-	org.apache.aries.javax.jax.rs-api;version='[0.0.1,0.0.2)',\
-	org.apache.aries.jax.rs.whiteboard;version='[0.0.1,0.0.2)',\
-	org.apache.felix.configadmin;version='[1.9.0,1.9.1)',\
+	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.0,1.0.1)',\
+	org.apache.felix.configadmin;version='[1.9.2,1.9.3)',\
 	org.apache.felix.http.jetty;version='[4.0.0,4.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.0,2.1.1)',\
@@ -43,4 +42,5 @@ Import-Package: org.osgi.framework.*;version="[1.8,2)",*
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.0,1.1.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	org.apache.johnzon.core;version='[1.1.0,1.1.1)'
+	org.apache.johnzon.core;version='[1.1.0,1.1.1)',\
+	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)'

--- a/examples/quickstart/app/app.bndrun
+++ b/examples/quickstart/app/app.bndrun
@@ -3,15 +3,14 @@ index: target/index.xml;name="app"
 -standalone: ${index}
 
 -runrequires: osgi.identity;filter:='(osgi.identity=org.osgi.enroute.examples.quickstart.rest)'
--runfw: org.apache.felix.framework
+-runfw: org.eclipse.osgi
 -runee: JavaSE-1.8
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	org.apache.aries.javax.annotation-api;version='[0.0.1,0.0.2)',\
-	org.apache.aries.javax.jax.rs-api;version='[0.0.1,0.0.2)',\
-	org.apache.aries.jax.rs.whiteboard;version='[0.0.1,0.0.2)',\
-	org.apache.felix.configadmin;version='[1.9.0,1.9.1)',\
+	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.0,1.0.1)',\
+	org.apache.felix.configadmin;version='[1.9.2,1.9.3)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.0,2.1.1)',\
 	org.osgi.enroute.examples.quickstart.rest;version='[0.0.1,0.0.2)',\
@@ -19,4 +18,5 @@ index: target/index.xml;name="app"
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.0,1.1.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	org.apache.felix.http.jetty;version='[4.0.0,4.0.1)'
+	org.apache.felix.http.jetty;version='[4.0.0,4.0.1)',\
+	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)'

--- a/indexes/enterprise-api/pom.xml
+++ b/indexes/enterprise-api/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.aries.spec</groupId>
             <artifactId>org.apache.aries.javax.jax.rs-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.aries.jpa.javax.persistence</groupId>

--- a/indexes/impl-index/pom.xml
+++ b/indexes/impl-index/pom.xml
@@ -39,12 +39,11 @@
     </pluginRepositories>
 
     <dependencies>
-        <!-- The OSGi framework RI is Equinox but that doesn't have a snapshot 
-            available -->
+        <!-- The OSGi framework RI is Equinox -->
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.framework</artifactId>
-            <version>5.7.0-SNAPSHOT</version>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <version>3.13.0</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -66,7 +65,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configadmin</artifactId>
-            <version>1.9.0</version>
+            <version>1.9.2</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -74,7 +73,14 @@
         <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.equinox.metatype</artifactId>
-            <version>1.4.200</version>
+            <version>1.4.400</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.metatype</artifactId>
+            <version>1.4.0</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -82,18 +88,18 @@
         <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.equinox.event</artifactId>
-            <version>1.3.200</version>
+            <version>1.4.200</version>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.event</artifactId>
-            <version>1.3.1</version>
+            <version>1.4.0</version>
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Log Service - it's not clear whether this is the RI -->
+        <!-- Log Stream Service -->
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.log</artifactId>
@@ -101,20 +107,9 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.log</artifactId>
-            <version>1.0.1</version>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.compendium</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.equinox.log.stream</artifactId>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- Http Whiteboard -->
@@ -185,7 +180,7 @@
         <dependency>
             <groupId>org.apache.aries.jax.rs</groupId>
             <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.0</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -193,7 +188,7 @@
         <dependency>
             <groupId>org.apache.aries.spec</groupId>
             <artifactId>org.apache.aries.javax.jax.rs-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.0</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -266,6 +261,13 @@
                     <artifactId>javax.persistence_2.0</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Used heavily in conjunction with JDBC -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.jdbc</artifactId>
+            <version>1.0.0</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Several implementations need to log using SLF4J -->


### PR DESCRIPTION
* Equinox 3.13.0 for R7 framework
* Eclipse Event 1.4.200 for Event Admin
* Eclipse Metatype 1.4.400 for Metatype
* Equinox Log Stream 1.0.0 for Log Stream service
* Aries JAX-RS Whiteboard 1.0.0 for JAX-RS Whiteboard

Fixes #66

Signed-off-by: Tim Ward <tim.ward@paremus.com>