### PR TITLE
Ensure that the examples can properly handle resolving on Java > 8

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -62,6 +62,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <bnd.version>4.1.0-SNAPSHOT</bnd.version>
     </properties>
 
     <modules>
@@ -154,7 +155,7 @@
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-maven-plugin</artifactId>
-                    <version>4.0.0</version>
+                    <version>${bnd.version}</version>
                     <configuration>
                         <bnd><![CDATA[
 Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
@@ -187,7 +188,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-export-maven-plugin</artifactId>
-                    <version>4.0.0</version>
+                    <version>${bnd.version}</version>
                     <executions>
                         <execution>
                             <goals>
@@ -201,7 +202,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-indexer-maven-plugin</artifactId>
-                    <version>4.0.0</version>
+                    <version>${bnd.version}</version>
                     <configuration>
                         <localURLs>REQUIRED</localURLs>
                         <attach>false</attach>
@@ -235,7 +236,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-resolver-maven-plugin</artifactId>
-                    <version>4.0.0</version>
+                    <version>${bnd.version}</version>
                     <configuration>
                         <failOnChanges>false</failOnChanges>
                         <bndruns>
@@ -254,7 +255,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-testing-maven-plugin</artifactId>
-                    <version>4.0.0</version>
+                    <version>${bnd.version}</version>
                     <executions>
                         <execution>
                             <goals>
@@ -270,7 +271,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-baseline-maven-plugin</artifactId>
-                    <version>4.0.0</version>
+                    <version>${bnd.version}</version>
                     <configuration>
                         <failOnMissing>false</failOnMissing>
                     </configuration>

--- a/indexes/impl-index/pom.xml
+++ b/indexes/impl-index/pom.xml
@@ -192,6 +192,41 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- JAX-B 2.2 API with contract -->
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jaxb_2.2_spec</artifactId>
+            <version>1.0.2-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Java-Activation 1.1 API with contract -->
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-activation_1.1_spec</artifactId>
+            <version>1.2-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Stax 1.2 API with contract -->
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-stax-api_1.2_spec</artifactId>
+            <version>1.3-SNAPSHOT</version>
+        </dependency>
+
+        <!-- JAX-WS 2.2 API with contract -->
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jaxws_2.2_spec</artifactId>
+            <version>1.3-SNAPSHOT</version>
+        </dependency>
+
+        <!-- SAAJ 1.3 API with contract -->
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-saaj_1.3_spec</artifactId>
+            <version>1.2-SNAPSHOT</version>
+        </dependency>
+
         <!-- OSGi Function -->
         <dependency>
             <groupId>org.osgi</groupId>


### PR DESCRIPTION
We need bnd 4.1.x to understand the base Java 9, 10 and 11 platforms properly, and we need to add a number of spec API bundles to replace packages that have been removed from the base JRE.

Signed-off-by: Tim Ward <tim.ward@paremus.com>