### PR TITLE
Use ServiceMix API Jars which are missing contracts but are released

### DIFF
--- a/indexes/impl-index/pom.xml
+++ b/indexes/impl-index/pom.xml
@@ -191,43 +191,43 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- JAX-B 2.2 API with contract -->
+        <!-- JAX-B 2.2 API -->
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jaxb_2.2_spec</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
+            <groupId>org.apache.servicemix.specs</groupId>
+            <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
+            <version>2.9.0</version>
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Java-Activation 1.1 API with contract -->
+        <!-- Java-Activation 1.1 API -->
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-activation_1.1_spec</artifactId>
-            <version>1.2-SNAPSHOT</version>
+            <groupId>org.apache.servicemix.specs</groupId>
+            <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
+            <version>2.9.0</version>
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Stax 1.2 API with contract -->
+        <!-- Stax 1.2 API -->
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-stax-api_1.2_spec</artifactId>
-            <version>1.3-SNAPSHOT</version>
+            <groupId>org.apache.servicemix.specs</groupId>
+            <artifactId>org.apache.servicemix.specs.stax-api-1.2</artifactId>
+            <version>2.9.0</version>
             <scope>runtime</scope>
         </dependency>
 
-        <!-- JAX-WS 2.2 API with contract -->
+        <!-- JAX-WS 2.2 API -->
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jaxws_2.2_spec</artifactId>
-            <version>1.3-SNAPSHOT</version>
+            <groupId>org.apache.servicemix.specs</groupId>
+            <artifactId>org.apache.servicemix.specs.jaxws-api-2.2</artifactId>
+            <version>2.9.0</version>
             <scope>runtime</scope>
         </dependency>
 
-        <!-- SAAJ 1.3 API with contract -->
+        <!-- SAAJ 1.3 API -->
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-saaj_1.3_spec</artifactId>
-            <version>1.2-SNAPSHOT</version>
+            <groupId>org.apache.servicemix.specs</groupId>
+            <artifactId>org.apache.servicemix.specs.saaj-api-1.3</artifactId>
+            <version>2.9.0</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
This will allow us to release OSGi enRoute R7 by removing snapshot dependencies

Signed-off-by: Tim Ward <tim.ward@paremus.com>