### PR TITLE
Updates to make enRoute palatable to Maven Central

### DIFF
--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -18,6 +18,16 @@
         <name>OSGi Alliance</name>
         <url>https://osgi.org/</url>
     </organization>
+    
+    <developers>
+        <developer>
+            <id>osgi</id>
+            <name>OSGi Alliance</name>
+            <email>info@osgi.org</email>
+            <organization>OSGi Alliance</organization>
+            <organizationUrl>https://www.osgi.org/</organizationUrl>
+        </developer>
+    </developers>
 
     <licenses>
         <license>
@@ -160,4 +170,28 @@
             </plugins>
         </pluginManagement>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,6 +18,16 @@
         <name>OSGi Alliance</name>
         <url>https://osgi.org/</url>
     </organization>
+    
+    <developers>
+        <developer>
+            <id>osgi</id>
+            <name>OSGi Alliance</name>
+            <email>info@osgi.org</email>
+            <organization>OSGi Alliance</organization>
+            <organizationUrl>https://www.osgi.org/</organizationUrl>
+        </developer>
+    </developers>
 
     <licenses>
         <license>
@@ -286,5 +296,59 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
             </plugins>
         </pluginManagement>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                     <failOnError>false</failOnError>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/examples/quickstart/app/pom.xml
+++ b/examples/quickstart/app/pom.xml
@@ -35,6 +35,10 @@
         <plugins>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-indexer-maven-plugin</artifactId>
             </plugin>
             <plugin>

--- a/examples/quickstart/app/src/main/java/config/package-info.java
+++ b/examples/quickstart/app/src/main/java/config/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * The quickstart example doesn't require any configuration.
+ * For more information about configuring applications take
+ * a look at the microservice example.
+ */
+package config;

--- a/examples/quickstart/app/src/main/resources/OSGI-INF/configurator/configuration.json
+++ b/examples/quickstart/app/src/main/resources/OSGI-INF/configurator/configuration.json
@@ -1,0 +1,11 @@
+{
+    // Comments are permitted in configuration files, but they should be
+    // minified if they are going to be used as strict JSON
+    
+    // Global Settings
+    ":configurator:resource-version" : 1,
+    ":configurator:symbolic-name" : "org.osgi.enroute.examples.quickstart.config",
+    ":configurator:version" : "0.0.2.SNAPSHOT",
+    
+    // There is no configuration for the quickstart application
+}

--- a/indexes/impl-index/pom.xml
+++ b/indexes/impl-index/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>impl-index</artifactId>
+    <packaging>pom</packaging>
 
     <description>An index containing the OSGi Reference Implementations used in OSGi enRoute</description>
 
@@ -333,38 +334,4 @@
         </dependency>
 
     </dependencies>
-
-
-    <build>
-        <plugins>
-            <!-- Generate the indexes -->
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-indexer-maven-plugin</artifactId>
-                <version>4.1.0</version>
-                <executions>
-                    <execution>
-                        <id>index</id>
-                        <goals>
-                            <goal>index</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Skip Empty Jar creation -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>default-jar</id>
-                        <configuration>
-                            <skipIfEmpty>true</skipIfEmpty>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/indexes/pom.xml
+++ b/indexes/pom.xml
@@ -18,6 +18,16 @@
         <name>OSGi Alliance</name>
         <url>https://osgi.org/</url>
     </organization>
+    
+    <developers>
+        <developer>
+            <id>osgi</id>
+            <name>OSGi Alliance</name>
+            <email>info@osgi.org</email>
+            <organization>OSGi Alliance</organization>
+            <organizationUrl>https://www.osgi.org/</organizationUrl>
+        </developer>
+    </developers>
 
     <licenses>
         <license>
@@ -83,4 +93,47 @@
         <module>debug-bundles</module>
         <module>test-bundles</module>
     </modules>
+    
+    <build>
+        <plugins>
+            <!-- Generate the indexes -->
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-indexer-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions>
+                    <execution>
+                        <id>index</id>
+                        <goals>
+                            <goal>index</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/indexes/test-bundles/pom.xml
+++ b/indexes/test-bundles/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>test-bundles</artifactId>
+    <packaging>pom</packaging>
 
     <description>An index containing bundles useful for unit testing and component testing</description>
 
@@ -23,37 +24,4 @@
             <version>2.13.0</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <!-- Generate the indexes -->
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-indexer-maven-plugin</artifactId>
-                <version>4.1.0</version>
-                <executions>
-                    <execution>
-                        <id>index</id>
-                        <goals>
-                            <goal>index</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Skip Empty Jar creation -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>default-jar</id>
-                        <configuration>
-                            <skipIfEmpty>true</skipIfEmpty>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
* Add JavaDoc and sources to application projects
* Add signatures to all project artifacts
* Add developer information to parent poms
* Add a release profile so that release data is only produced when needed

Signed-off-by: Tim Ward <tim.ward@paremus.com>