### PR TITLE
Added Gitpod Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1><img src="http://enroute.osgi.org/img/enroute-logo-64.png" witdh=40px style="float:left;margin: 0 1em 1em 0;width:40px">
 OSGi enRoute</h1>
 
-[![Gitpod - Code Now](https://img.shields.io/badge/Gitpod-code%20now-blue.svg?longCache=true)](https://gitpod.io#https://github.com/osgi/osgi.enroute/tree/master/examples/quickstart)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/Sandared/jmh-benchmarks/blob/master/benchmarks/src/main/java/io/jatoms/jmh/OSGiBenchmark2.java)
 
 Interested in developing agile & maintainable Enterprise or highly distributed IoT solutions? In either case, [OSGi enRoute](http://enroute.osgi.org) provides a simple on-ramp for developing such modular distributed applications and exploring the power of OSGi.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <h1><img src="http://enroute.osgi.org/img/enroute-logo-64.png" witdh=40px style="float:left;margin: 0 1em 1em 0;width:40px">
 OSGi enRoute</h1>
 
+[![Gitpod - Code Now](https://img.shields.io/badge/Gitpod-code%20now-blue.svg?longCache=true)](https://gitpod.io#https://github.com/osgi/osgi.enroute/tree/master/examples/quickstart)
+
 Interested in developing agile & maintainable Enterprise or highly distributed IoT solutions? In either case, [OSGi enRoute](http://enroute.osgi.org) provides a simple on-ramp for developing such modular distributed applications and exploring the power of OSGi.
 
 Based upon the latest OSGi best practices and R7 Specifications, the enRoute tutorials start with a comprehensive hands-on introduction to Declarative Services, and then progresses to explore OSGi's unique and powerful approaches to Microservices & Reactive Systems.
@@ -9,7 +11,7 @@ This repository contains the code for the enRoute tutorials, and also defines us
 
 ## Contributing
 
-Want to contribite to osgi.enroute? See [CONTRIBUTING.md](CONTRIBUTING.md) for information on building, testing and contributing changes.
+Want to contribute to osgi.enroute? See [CONTRIBUTING.md](CONTRIBUTING.md) for information on building, testing and contributing changes.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1><img src="http://enroute.osgi.org/img/enroute-logo-64.png" witdh=40px style="float:left;margin: 0 1em 1em 0;width:40px">
 OSGi enRoute</h1>
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/Sandared/jmh-benchmarks/blob/master/benchmarks/src/main/java/io/jatoms/jmh/OSGiBenchmark2.java)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/osgi/osgi.enroute/blob/master/examples/quickstart/rest/src/main/java/org/osgi/enroute/examples/quickstart/rest/Upper.java)
 
 Interested in developing agile & maintainable Enterprise or highly distributed IoT solutions? In either case, [OSGi enRoute](http://enroute.osgi.org) provides a simple on-ramp for developing such modular distributed applications and exploring the power of OSGi.
 
@@ -11,7 +11,7 @@ This repository contains the code for the enRoute tutorials, and also defines us
 
 ## Contributing
 
-Want to contribute to osgi.enroute? See [CONTRIBUTING.md](CONTRIBUTING.md) for information on building, testing and contributing changes.
+Want to contribite to osgi.enroute? See [CONTRIBUTING.md](CONTRIBUTING.md) for information on building, testing and contributing changes.
 
 ## License
 


### PR DESCRIPTION
I added a Gitpod Button to Readme.md. 

Now all a user has to do to run the quickstart is to 
* open Gitpod
* cd to examples/quickstart
* mvn verify
* run the jar. 

Even a preview is given within Gitpod
Further enhancements could be to add a gitpod config file to the repository that already contains thos steps as setup command and exposes port 8080 by default. This way a user directly lands in a wowrkspace where everything is running and he can play araound with the code.

Signed-off-by: Thomas Driessen <thomas.driessen.td@gmail.com>