### PR TITLE
Switch to building with OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - unset _JAVA_OPTIONS


### PR DESCRIPTION
Oracle JDK 8 is no longer available on Travis

Signed-off-by: Tim Ward <tim.ward@paremus.com>